### PR TITLE
CS-5335: Fixes layout issue with Recaptcha showing privacy & terms link ...

### DIFF
--- a/_css/quetzal.layout.css
+++ b/_css/quetzal.layout.css
@@ -659,7 +659,7 @@ article.main-article .addthis_toolbox {
   margin-bottom: 100px;
 }
 #recaptcha_response_field {
-  height: 32px !important;
+  height: auto !important;
 }
 .audiojs {
   width: 60%;

--- a/_css/quetzal.layout.less
+++ b/_css/quetzal.layout.less
@@ -735,8 +735,8 @@ article.main-article{
     }
 }
 
-#recaptcha_response_field{
-    height: 32px !important;
+#recaptcha_response_field {
+    height: auto !important;
 }
 
 .audiojs {

--- a/_css/quetzal.skin.css
+++ b/_css/quetzal.skin.css
@@ -659,7 +659,7 @@ article.main-article .addthis_toolbox {
   margin-bottom: 100px;
 }
 #recaptcha_response_field {
-  height: 32px !important;
+  height: auto !important;
 }
 .audiojs {
   width: 60%;


### PR DESCRIPTION
...in certain languages

In English the link 'Privacy & terms' is shown for the Recaptcha widget. Because of the styling of the textfield this conflicts and creates a distorted widget. This fixes the issue, all though undoes a bit of styling for the input field, so it doesn't look 100% like the other input fields any more.
